### PR TITLE
fix: fix style projects cards on page projects on 1366 (auto-fill)

### DIFF
--- a/src/components/Projects/Projects.scss
+++ b/src/components/Projects/Projects.scss
@@ -64,7 +64,7 @@
 		}
 		&__cards {
 			gap: 12px;
-			grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+			grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
 		}
 		&__label-btn {
 			width: 280px;


### PR DESCRIPTION
Правка карточки проекта на странице Проекты на 1366 (в стилях сделала auto-fill, чтобы одна карточка не растягивалась на весь экран)